### PR TITLE
change config access to function instead of fucntion in constant

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -208,7 +208,11 @@ const configSchema = {
     }
 };
 
-export const getConfig = Memoizer.makeMemoized(loadConfiguration);
+
+const getConfigInternal = Memoizer.makeMemoized(loadConfiguration);
+export function getConfig() {
+    return getConfigInternal();
+}
 
 function loadConfiguration() {
     try {


### PR DESCRIPTION
Export a function instead of a const that is actually a function (just a bit nicer)